### PR TITLE
add references for SIPs 1–7

### DIFF
--- a/001.md
+++ b/001.md
@@ -10,11 +10,7 @@ License: CC0-1.0
 
 The `ssb` scheme is registered as [provisional under the IANA](https://www.iana.org/assignments/uri-schemes/prov/ssb), but its format is not yet specified accessibly and clearly. This documents aims at providing the first specification of SSB URIs, as they are used in existing applications and will be adopted increasingly in more use cases.
 
-## Terminology
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-
-## Prior work
+## Motivation
 
 There is a thread on SSB, `%g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=.sha256`, where several participants gave their thoughts on the design of the SSB URI format, with several proposals put into consideration. The format of Query-only URIs were inspired by [Magnet URIs](https://www.iana.org/assignments/uri-schemes/prov/magnet).
 
@@ -22,7 +18,11 @@ There is a thread on SSB, `%g3hPVPDEO1Aj/uPl0+J2NlhFB2bbFLIHlty+YuqFZ3w=.sha256`
 
 The specification in this document is compatible with `ssb-uri` while adding support for expressing more resources.
 
-## List
+## Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Specification
 
 - **Canonical SSB URIs**
   - `ssb:message/classic/<MSGID>`
@@ -48,7 +48,7 @@ The specification in this document is compatible with `ssb-uri` while adding sup
   - `ssb:feed/ed25519/<FEEDID>`
   - `ssb:blob/sha256/<BLOBID>`
 
-## Overview
+### Overview
 
 There are two main categories of SSB URIs: **Canonical** and **Experimental**. The conceptual difference between these two is that canonical SSB URIs make use of the **path component** in the URI to specify the resource, while experimental SSB URIs use *only* the **query component** to specify the resource.
 
@@ -161,6 +161,22 @@ ssb:experimental?action=start-http-auth&sid=<SID>&sc=<SC>
 ### Process to canonicalize SSB URIs
 
 When experimental SSB URIs are adopted by SSB applications, if they are deemed useful and long-term URIs, there should be discussion among stakeholders (SSB application developers, and protocol developers) to specify a canonical SSB URI format (using path component) to replace the experimental SSB URI. Then, the new canonical SSB URI should be specified in this document.
+
+## References
+
+### Normative
+
+- [SSB URI at IANA](https://www.iana.org/assignments/uri-schemes/prov/ssb)
+- [RFC3986 Section 2.1](https://tools.ietf.org/html/rfc3986#section-2.1)
+- [multiserver addresses](https://github.com/ssbc/multiserver-address)
+
+### Informative
+
+- [Magnet URIs](https://www.iana.org/assignments/uri-schemes/prov/magnet)
+
+### Implementation
+
+- [ssbc/ssb-uri2](https://github.com/ssbc/ssb-uri2) in JavaScript
 
 ## Appendix A. Grammar
 

--- a/002.md
+++ b/002.md
@@ -30,7 +30,7 @@ Metafeeds will use a specialized feed format known as [bendy butt] that aims
 to be very easy to implement. The aim is that this will make it easier for
 implementations which do not need or want to support the classical SSB format.
 
-## Definitions
+## Terminology
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
@@ -38,7 +38,9 @@ interpreted as described in RFC 2119.
 
 We use bencode and [BFE] notations as defined in the [bendy butt] spec.
 
-## Usage of Bendy Butt feed format
+## Specification
+
+### Usage of Bendy Butt feed format
 
 Metafeeds **MUST** use the [bendy butt] feed format with a few additional
 constraints.
@@ -61,7 +63,7 @@ to a BFE "arbitrary bytes" with size 32, i.e. `<06 03> + nonce32bytes`
 The `contentSignature` field inside a decrypted `contentSection` **MUST** use
 the `subfeed`'s cryptographic keypair.
 
-## Example of a metafeed
+### Example of a metafeed
 
 Here is an an example of a metafeed with 2 subfeeds: one for `main`
 social data and another one for `application-x` in a different format.
@@ -135,7 +137,7 @@ is currently not supported.
 seems redundant, it is important to have it and check that the `metafeed` field
 equals the author of the metafeed itself to protect against replay attacks.
 
-## Applications example
+### Applications example
 
 An example of the applications metafeed with two different
 applications.
@@ -171,7 +173,7 @@ digraph Applications {
 }
 ```
 
-## Tree structure
+### Tree structure
 
 Since a subfeed can be a metafeed itself, this means that the relationships
 between subfeeds and metafeeds is a tree. We refer to the top-most metafeed as
@@ -194,7 +196,7 @@ by grouping together feeds that are part of the same application under a common
 metafeed, we can skip replication of those application feeds if they are not
 relevant to the user.
 
-### v1
+#### v1
 
 This section describes the specification of the organization of subfeeds under
 the `v1` versioning subfeed.
@@ -271,12 +273,12 @@ It is **RECOMMENDED** that the application-specific subfeeds are leafs in the
 tree, but they **MAY** be metafeeds that contain other application-specific
 subfeeds.
 
-## Key management, identity and metadata
+### Key management, identity and metadata
 
 As mentioned earlier, in classical SSB the feed identity is the same
 as the feed. Here instead we want to decouple identity and feeds.
 
-### Existing SSB identity
+#### Existing SSB identity
 
 To generate a metafeed and link it to an existing `main` feed, first
 a seed is generated:
@@ -369,7 +371,7 @@ A feed can only have **one** metafeed. If for whatever reason an
 existing metafeed needs to be superseed, a new message is created
 pointing to the previous `metafeed/announce` message via the tangle.
 
-### New SSB identity
+#### New SSB identity
 
 A new identity also starts by constructing a seed. From this seed both
 the metafeed keys and the main feed keys are generated. The main
@@ -396,7 +398,7 @@ message on the metafeed.
 The seed will also be encrypted to the main feed and the metafeed
 linked to the main feed just like for existing feeds.
 
-### Identity backwards compatibility
+#### Identity backwards compatibility
 
 By building a layer on top of existing feeds we maintain backwards
 compatible with existing clients. The identity to be used by new
@@ -418,12 +420,12 @@ Using [BIP32-Ed25519] instead was considered but that method has a
 weaker security model in the case of a key compromised where keys are
 shared between devices.
 
-## Use cases
+### Use cases
 
 Let us see how we can use the above abstraction to solve several
 common examples:
 
-### New feed format
+#### New feed format
 
 Changing to a new feed format could be implemented by adding a new
 feed to the metafeed state, and by adding a tombstone message to the
@@ -440,7 +442,7 @@ the corresponding message in old feed in the newer feed.
 Lower end clients could offload this extra storage requirement to
 larger peers in the network.
 
-### Claims or indexes
+#### Claims or indexes
 
 For classical SSB feeds if one would like to replicate a specific part
 of a feed, such as the contact messages, one could request another
@@ -451,7 +453,7 @@ messages were not left out. Naturally this comes down to trust
 then. Using the friend graph would be natural, as would using trustnet
 together with audits of these claims.
 
-### Subfeeds
+#### Subfeeds
 
 Similar to claims it would be possible to create subfeeds that would
 only contain certain messages. This might be useful for specific
@@ -460,14 +462,14 @@ specific messages are picked out that might be of particular interest
 to a certain application or specific people, or say messages within
 the last year.
 
-### Ephemeral feeds
+#### Ephemeral feeds
 
 Using the metadata it would be possible to attach a lifetime to feeds,
 meaning honest peers would delete the feeds after a specific
 time. This would enable applications to generate a short lived feed
 only for the communication between two parties.
 
-### Allow list
+#### Allow list
 
 Similar to ephemeral feeds it would be possible to attach an allow
 list to a feed and only distribute this feed to people on the allow
@@ -476,7 +478,7 @@ honest peers would give piece of mind that the data is only stored on
 a certain subset of the whole network. This can naturally be combined
 with private groups to better ensure safety.
 
-## Open questions
+### Open questions
 
 - In the case of claims, how are bad actors handled?
 - What are the broader consequences of ephemeral feeds. Maybe they can
@@ -484,10 +486,24 @@ only be used in limited circumstances, and if so which ones?
 - For subfeeds and feed rotation what is the best way to handle
   potentially overlapping messages
 
-## Acknowledgments and prior work
+## References
+
+### Normative
+
+- [SIP 4](./004.md) "Bendy Butt"
+
+### Informative
+
+- [BIP32-Ed25519]
+
+### Implementation
+
+- [ssbc/ssb-meta-feeds](https://github.com/ssbc/ssb-meta-feeds) in JavaScript
+
+### Acknowledgments and prior work
 
 CFT suggested the use of metafeeds
-[in](https://github.com/arj03/ssb-observables/issues/1)
+in [ssb-observables issue 1](https://github.com/arj03/ssb-observables/issues/1).
 
 [BIP32-Ed25519]: https://github.com/wallet-io/bip32-ed25519/blob/master/doc/Ed25519_BIP.pdf
 [ssb-secure-partial-replication]: https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication

--- a/003.md
+++ b/003.md
@@ -13,7 +13,7 @@ along with the structure of index feed messages. To understand how
 index feeds are used to migrate from classic feeds to metafeeds see
 [migration spec].
 
-## Indexes
+## Specification
 
 There are two versions of spec for "index feeds". Version 0 should be
 considered deprecated and does not need to be supported. Version 1
@@ -99,6 +99,20 @@ Index message format in a classic SSB feed:
 The `indexed.sequence` might seem redundant but it might be much cheaper
 for an implementation to resolve `author@sequence` and checking the hash
 of the message then keeping a total `hash => message` index.
+
+## References
+
+### Normative
+
+- [ssb-ql-0]
+
+### Informative
+
+- [migration spec]
+
+### Implementation
+
+- [ssbc/ssb-index-feeds](https://github.com/ssbc/ssb-index-feeds/) in JavaScript
 
 [ssb-ql-0]: https://github.com/ssb-ngi-pointer/ssb-subset-replication-spec#ssb-ql-0
 [migration spec]: https://github.com/ssbc/ssb-meta-feeds-migration

--- a/004.md
+++ b/004.md
@@ -43,7 +43,7 @@ Can I use Bendy Butt for purposes other than meta feeds?
 > To preserve the simplicity of this spec, we recommend not sending
 > patches to the spec to generalize it.
 
-## Definitions
+## Terminology
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
@@ -106,7 +106,7 @@ SSB format (ed25519).
 The key or ID of a Bendy Butt message is the SHA256 hash of the bencoded bytes
 for `[payload, signature]`, i.e. `key = SHA256([payload, signature])`.
 
-## Example
+### Example
 
 Following our `[a, b]` and `{ "a" => 1, "b" => 2}` notation, which may look
 similar to JSON, here is a Bendy Butt message with the `content` dictionary
@@ -171,7 +171,7 @@ Here is the same data as above, but displayed in raw binary (hexadecimal):
 ```
 
 
-## Validation
+### Validation
 
 For validation we differentiate between *message validity* and *content
 validity*. Since the content can be encrypted, there is potentially no way to
@@ -193,6 +193,23 @@ The message **MUST** conform to the following rules:
 
 Under the Bendy Butt spec, the content is free-form, but under the [meta feeds]
 spec there are strict constraints applied to this bencode dictionary.
+
+## References
+
+### Normative
+
+- [SSB-BFE]
+- [bencode]
+- [bencode integer]
+
+### Informative
+
+- [gabby grove]
+- [bamboo]
+
+### Implementation
+
+- [ssbc/ssb-bendy-butt](https://github.com/ssbc/ssb-bendy-butt) in JavaScript
 
 [SSB]: https://github.com/ssbc/
 [gabby grove]: https://github.com/ssbc/ssb-spec-drafts/tree/master/drafts/draft-ssb-core-gabbygrove/00

--- a/005.md
+++ b/005.md
@@ -37,8 +37,8 @@ This specification makes clear assumptions about the setup involved peers authen
         1. The server **SHOULD** store the client's `userId` and allow the client to access resources on the server, effectively making the client a recognized member
         1. The server **MUST** respond with header `Content-Type` equal `application/json` and body `{"multiserverAddress":"${serverMsAddr}"}` where `${serverMsAddr}` consititutes the server's multiserver address
 1. The client receives the `submissionUrl` response, parses `${serverMsAddr}` from the response body, and **MAY** use that multiserver address to create a muxrpc connection with the server
-1. If the server receives a muxrpc connection from the client, it **MUST** authorize it and grant them a [tunnel address](Tunnel%20addresses.md)
-1. The client is now an Internal User
+1. If the server receives a muxrpc connection from the client, it **MUST** authorize it and grant them internal access
+1. The client is now authenticated
 
 The JSON schemas for which the response from the `submissionUrl` **MUST** conform to is shown below.
 
@@ -158,7 +158,7 @@ As an additional endpoint for programmatic purposes, if the query parameter `enc
 }
 ```
 
-## Example
+### Example
 
 Suppose the client has the SSB ID `@FlieaFef19uJ6jhHwv2CSkFrDLYKJd/SuIS71A5Y2as=.ed25519` and the server is hosted at `scuttlebutt.eu`. Then the invite user journey is:
 
@@ -205,7 +205,23 @@ Specifically, these instructions can also use mobile operating systems deep link
 
 ### Malicious web visitor
 
-A web visitor, either human or bot, could attempt brute force visiting all possible invite URLs, in order to force themselves to become an [internal user](../Stakeholders/Internal%20user.md). However, this could easily be mitigated by rate limiting requests by the same IP address.
+A web visitor, either human or bot, could attempt brute force visiting all possible invite URLs, in order to authenticate themselves. However, this could easily be mitigated by rate limiting requests by the same IP address.
+
+## References
+
+### Normative
+
+- [SIP 1](./001.md) "SSB URIs"
+
+### Informative
+
+- [UX Research for Manyverse](https://www.manyver.se/ux-research/)
+
+### Implementation
+
+- [ssbc/go-ssb-room](https://github.com/ssbc/go-ssb-room/) server in Go
+- [ssbc/ssb-http-invite-client](https://github.com/ssbc/ssb-http-invite-client)
+client library in JavaScript
 
 ## Appendix A. List of new SSB URIs
 

--- a/006.md
+++ b/006.md
@@ -165,6 +165,25 @@ Because the sign-in process is seemless and happens in the background via muxrpc
 
 SSB applications that control the client SSB peer therefore MUST prompt user consent before `httpAuth.requestSolution` or `httpAuth.sendSolution` are sent. The prompt SHOULD display the server's SSB ID and ask the user to confirm their intent to sign-in.
 
+## References
+
+### Normative
+
+- [SIP 1](./001.md) "SSB URIs"
+- [Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html)
+
+### Informative
+
+- [Wikipedia: challenge-response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication)
+- [Wikipedia: cryptographic nonces](https://en.wikipedia.org/wiki/Cryptographic_nonce)
+
+### Implementation
+
+- [ssbc/go-ssb-room](https://github.com/ssbc/go-ssb-room/) server in Go
+- [ssbc/ssb-http-auth-client](https://github.com/ssbc/ssb-http-auth-client)
+client library in JavaScript
+
+
 ## Appendix A. List of required HTTP endpoints
 
 - `/login`

--- a/007.md
+++ b/007.md
@@ -747,13 +747,13 @@ Similar considerations as with the room admin, but less powers. The malicious mo
 
 ## References
 
-### Normative references
+### Normative
 
-- SIP 5: HTTP Invites
-- SIP 6: HTTP Authentication
+- [SIP 5](./005.md) "HTTP Invites"
+- [SIP 6](./006.md) "HTTP Authentication"
 - [RFC 1035](https://tools.ietf.org/html/rfc1035).
 
-### Informative references
+### Informative
 
 - [SSB Rooms 1](https://github.com/staltz/ssb-room)
 - [Email addresses](https://en.wikipedia.org/wiki/Email_address)
@@ -763,6 +763,10 @@ Similar considerations as with the room admin, but less powers. The malicious mo
 - [Secret Handshake](https://ssbc.github.io/scuttlebutt-protocol-guide/#handshake)
 - [Box Stream](https://ssbc.github.io/scuttlebutt-protocol-guide/#box-stream)
 - [muxrpc](https://github.com/ssb-js/muxrpc/)
+
+### Implementation
+
+- [ssbc/go-ssb-room](https://github.com/ssbc/go-ssb-room/) in Go
 
 ## Appendix A. List of muxrpc APIs
 


### PR DESCRIPTION
I wanted to especially add reference implementations, but also took the opportunity to add normative and informative. As well as standardize a bit the document structures.